### PR TITLE
Removed action id in response as it is not required

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -131,7 +131,6 @@ type ActionRequest struct {
 
 // ActionResponse can be sent in order to inform about the state of an action
 type ActionResponse struct {
-	ID     string                      `json:"id"`
 	Status restapi.ActionRequestStatus `json:"status"`
 	Error  string                      `json:"error"`
 }


### PR DESCRIPTION
The action response id can be internally set by connectorhub